### PR TITLE
deps: bump transitive security floors to clear Dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,10 @@ settings:
 
 overrides:
   '@astrojs/language-server': 2.16.11
-  brace-expansion: 5.0.7
+  brace-expansion: 5.0.8
   esbuild: 0.28.1
-  js-yaml: 4.2.0
+  fast-uri: 3.1.4
+  js-yaml: 4.3.0
   vite: 8.1.5
   yaml: 2.9.0
 
@@ -1504,9 +1505,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1867,8 +1868,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -2072,8 +2073,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -3352,7 +3353,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       picomatch: 4.0.5
       retext-smartypants: 6.2.0
       shiki: 4.3.1
@@ -3363,7 +3364,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       picomatch: 4.0.5
       retext-smartypants: 6.2.0
       shiki: 4.3.1
@@ -4383,7 +4384,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4457,7 +4458,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
@@ -4537,7 +4538,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4927,7 +4928,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -5206,7 +5207,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -5812,7 +5813,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   mj-context-menu@0.6.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,9 @@ allowBuilds:
 
 overrides:
   '@astrojs/language-server': 2.16.11
-  brace-expansion: 5.0.7
+  brace-expansion: 5.0.8
   esbuild: 0.28.1
-  js-yaml: 4.2.0
+  fast-uri: 3.1.4
+  js-yaml: 4.3.0
   vite: 8.1.5
   yaml: 2.9.0


### PR DESCRIPTION
Clears every open Dependabot alert. All four advisories are on transitive dependencies, so they are fixed by raising the version floors in the existing `overrides` block in `pnpm-workspace.yaml` — no direct dependency changes.

| Package | Before | After | Advisory | Path |
| --- | --- | --- | --- | --- |
| `brace-expansion` | 5.0.7 | 5.0.8 | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (CVE-2026-14257, high) — OOM crash via unbounded expansion length | `@typescript-eslint/parser > typescript-estree > minimatch` |
| `js-yaml` | 4.2.0 | 4.3.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (CVE-2026-59869, high) — quadratic CPU via merge-key chains | `@astrojs/markdown-remark > @astrojs/internal-helpers` |
| `fast-uri` | 3.1.2 | 3.1.4 | [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) (CVE-2026-16221, high) and [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) (CVE-2026-13676, high) — host confusion | `@astrojs/check > @astrojs/language-server > volar-service-yaml > yaml-language-server > ajv` |

`fast-uri` is a new override entry; the other two already had pins that are now raised. `js-yaml` stays on the v4 line (4.3.0 is the patched `v4-legacy` release) to keep the consumer's `^4` range satisfiable — v5 would be an unnecessary major jump for a transitive pin.

## Verification

- `pnpm audit` → **No known vulnerabilities found** (was 4 high)
- `astro check` → 0 errors, 0 warnings, 0 hints
- `pnpm lint` → clean
- `pnpm format:check` → clean

`pnpm build` was not run to completion here: it fails in this sandbox at OG-image generation because outbound requests to `fonts.google.com` are blocked (`403 Forbidden` from the egress proxy), which is unrelated to this change. The `astro check` and Vite build phases that precede it both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XihLhFH2pF3gFvhc9dncmz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XihLhFH2pF3gFvhc9dncmz)_